### PR TITLE
Fixed clippy lints

### DIFF
--- a/formframe/src/cli.rs
+++ b/formframe/src/cli.rs
@@ -160,12 +160,13 @@ impl Into<Subject> for &DataInit {
 }
 
 impl DataInit {
-    fn and(&self, other: Self) -> Option<()> {
-        match (self.is_set(), other.is_set()) {
-            (true, true) => Some(()),
-            (_, _) => None,
-        }
-    }
+    // Will be needed once UnixListener is implemented
+    // fn and(&self, other: Self) -> Option<()> {
+    //     match (self.is_set(), other.is_set()) {
+    //         (true, true) => Some(()),
+    //         (_, _) => None,
+    //     }
+    // }
 
     fn is_set(&self) -> bool {
         !self.is_empty()

--- a/formframe/src/error.rs
+++ b/formframe/src/error.rs
@@ -232,8 +232,8 @@ where
         String::default(),
         |mut out, (_, last, cxt)| {
             match (cxt, last) {
-                (cxt, false) => out.extend([rcxt_display(cxt), ","].iter().map(|s| *s)),
-                (cxt, true) => out.extend([rcxt_display(cxt)].iter().map(|s| *s)),
+                (cxt, false) => out.extend([rcxt_display(cxt), ","].iter().copied()),
+                (cxt, true) => out.extend([rcxt_display(cxt)].iter().copied()),
             };
 
             out

--- a/formframe/src/graph.rs
+++ b/formframe/src/graph.rs
@@ -10,9 +10,10 @@ pub struct Node<T> {
 }
 
 impl<T> Node<T> {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(datum: T, arena: &mut Arena<Node<T>>) -> Index {
         arena.insert(Node {
-            datum: datum,
+            datum,
             edges: OnceCell::new(),
         })
     }
@@ -29,10 +30,6 @@ impl<T> Node<T> {
         F: Fn(&Arena<Node<T>>, &T, &[Index]) -> R,
         R: Sized + Send + Sync,
     {
-        traverse(
-            arena,
-            &self.datum,
-            self.edges.get_or_init(|| Default::default()),
-        )
+        traverse(arena, &self.datum, self.edges.get_or_init(Default::default))
     }
 }

--- a/formframe/src/load/error.rs
+++ b/formframe/src/load/error.rs
@@ -41,9 +41,9 @@ pub enum Err {
 }
 
 impl Err {
-    fn categorize(&self) -> Category {
-        self.into()
-    }
+    // fn categorize(&self) -> Category {
+    //     self.into()
+    // }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/formframe/src/load/filter.rs
+++ b/formframe/src/load/filter.rs
@@ -65,7 +65,7 @@ pub fn serial_traverse(
         // Wait for all success / return on first error
         NodeType::And => {
             let res: Result<(), ()> = edges
-                .into_iter()
+                .iter()
                 .map(|idx| {
                     arena
                         .get(*idx)
@@ -84,7 +84,7 @@ pub fn serial_traverse(
         // Return first success / wait for all failure
         NodeType::Or => {
             let res: Result<(), ()> = edges
-                .into_iter()
+                .iter()
                 .map(|idx| {
                     arena
                         .get(*idx)
@@ -223,8 +223,8 @@ pub enum BoolExt {
 }
 
 impl BoolExt {
-    fn as_bool(&self) -> bool {
-        (*self).into()
+    fn as_bool(self) -> bool {
+        self.into()
     }
 }
 
@@ -303,5 +303,5 @@ where
 {
     let type_hint: String = Deserialize::deserialize(de)?;
 
-    Regex::new(&type_hint).map_err(|e| de::Error::custom(e))
+    Regex::new(&type_hint).map_err(de::Error::custom)
 }

--- a/formframe/src/main.rs
+++ b/formframe/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::match_bool)]
+
 use {
     crate::{
         cli::{generate_cli, ProgramArgs},

--- a/formframe/src/models/mod.rs
+++ b/formframe/src/models/mod.rs
@@ -33,10 +33,7 @@ pub fn check_args() -> MainResult<()> {
     let args = ARGS.as_ref();
     match args {
         Ok(_) => Ok(()),
-        Err(e) => {
-            let e = Err(e.into());
-            e
-        }
+        Err(e) => Err(e.into()),
     }
 }
 

--- a/formframe/src/models/tcp.rs
+++ b/formframe/src/models/tcp.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use {
     crate::{
         models::{Data, LocalRecord},
@@ -62,7 +64,7 @@ pub async fn listener(addr: &str) -> Result<()> {
                                                     out
                                                 } else {
                                                     let (tx, rx) = channel::<Data>(256);
-                                                    map.insert(header.id.clone(), tx);
+                                                    map.insert(header.id, tx);
                                                     tokio::spawn(handle_join(rx));
                                                     out
                                                 }
@@ -135,7 +137,7 @@ where
         }))
 }
 
-async fn handle_join(rx: Receiver<Data>) {
+async fn handle_join(_rx: Receiver<Data>) {
     unimplemented!()
 }
 


### PR DESCRIPTION
In preparation for the master fastforward, I fixed most of the clippy lints.
Two exceptions: I blanket allow bool matching, because I find it much more readable & formframe/models/tcp.rs is currently #![allow(dead_code)] due to its WIP nature. 
